### PR TITLE
add vendor/bundle to exclusion list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,5 +32,6 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor/bundle
 include:
   - lore


### PR DESCRIPTION
bundle includes a copy of jekyll itself, which has some extra tests
that can throw off building the site locally.

Relevant docs:
* https://jekyllrb.com/docs/troubleshooting/#configuration-problems

Relevant issue:
* jekyll/jekyll#2938

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>