### PR TITLE
Allow repo to render lore submodule markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "jekyll-theme-tactile"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.0"
 
+# This will ensure relative links in markdown files are processed correctly by Jekyll.
+gem 'jekyll-relative-links'
+
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 # gem "github-pages", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -32,5 +32,6 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor/bundle
 include:
   - lore

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ markdown: kramdown
 theme: minima
 gems:
   - jekyll-feed
+  - jekyll-relative-links
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+
+  {% include head.html %}
+
+  <body>
+
+    {% include header.html %}
+
+    <main class="page-content" aria-label="Content">
+      <div class="wrapper">
+        {{ content }}
+      </div>
+    </main>
+
+    {% include footer.html %}
+
+  </body>
+
+</html>


### PR DESCRIPTION
Allow repo to render lore submodule markdown
    
* add jekyll-relative-links to required gems so relative links in lore
   repo are followed correctly.
* add default layout for lore headers to reference. This will ensure
   that the site styling is kept consistent when viewing lore.
    
Depends-On: #1
    
Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>