### PR TITLE
Turn off markdownlint first-line-header rule

### DIFF
--- a/.markdownlint.js
+++ b/.markdownlint.js
@@ -33,6 +33,6 @@
   "no-space-in-code": true,
   "no-space-in-links": true,
   "fenced-code-language": true,
-  "first-line-h1": { "level": "1" },
+  "first-line-h1": false,
   "no-empty-links": true
 }


### PR DESCRIPTION
Since we're using jekyll for github.bonnyci.com, we need a bit of YAML
at the beginning of our markdown files for our lore to be rendered
correctly by jekyll. This throws off the first-line-header rule we have
set for markdownlint.

Related doc:
http://jekyllrb.com/docs/frontmatter/

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>