### PR TITLE
Begin migration of bonnyci.org to using .bonnyci/run.sh

### DIFF
--- a/.bonnyci/run.sh
+++ b/.bonnyci/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+sudo apt-get install -y curl
+curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+sudo apt-get install -y nodejs
+./tests/markdownlint-cli-test.sh
+./tests/shellcheck-test.sh
+./tests/signed-off-by-test.sh


### PR DESCRIPTION
This is the first step in moving the actual test execution out of hoist's
zuul layout and into the repo.  A follow up patch will need to land in
hoist to update the project to run the bonnyci-run-check/gate jobs instead
of bonnyci.org tests.