### PR TITLE
Remove Travis build status icon for lore

### DIFF
--- a/lore/README.md
+++ b/lore/README.md
@@ -8,8 +8,6 @@ show_header_link: true
 
 # BonnyCI Documentation
 
-[![Build Status](https://travis-ci.org/BonnyCI/lore.svg?branch=master)](https://travis-ci.org/BonnyCI/lore)
-
 ## Table of Contents
 
 * [Introduction](#introduction)


### PR DESCRIPTION
Previously, we still included the icon for the Travis CI build status
for the lore repository. Since this is no longer needed, it has been
removed.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>