### PR TITLE
Add links to all status pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,4 @@ exclude:
   - vendor/bundle
 include:
   - lore
+  - status

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,6 @@
       </span>
 
       <div class="trigger">
-          <a class="page-link" href="http://zuul.bonnyci.org/">Status</a>
         {% for my_page in site.pages %}
           {% if my_page.title and my_page.show_header_link %}
           <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>

--- a/lore/end_users/README.md
+++ b/lore/end_users/README.md
@@ -32,4 +32,4 @@ Check out the [feature request documentation](issues/README.md#feature-requests)
 
 ## Status Page
 
-Check out the [status page](https://p.datadoghq.com/sb/cbf19e221-1b77fb05f2) to see some monitoring and metrics for BonnyCI. For detailed explanations of what the items on this page mean, check out out the [status page documentation](status/README.md).
+Check out the [status page](../../status) for a list of BonnyCI's status pages.

--- a/status/README.md
+++ b/status/README.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: "Status"
+permalink: /status/
+show_header_link: true
+---
+
+# BonnyCI Status
+
+There are three status pages for BonnyCI:
+
+* [Zuul Status](http://zuul.bonnyci.org/)
+* [BonnyCI Status ScreenBoard](https://p.datadoghq.com/sb/cbf19e221-1b77fb05f2)
+  * See our [status page documentation](http://bonnyci.org/lore/end_users/status) for detailed explanations of what each item means
+* [Build Status](https://travis-ci.org/BonnyCI)


### PR DESCRIPTION
Previously, we had dispersed links to BonnyCI status pages. Now they all
on [bonnyci.org/status](http://bonnyci.org/status).

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>