### PR TITLE
Add a basic README.md to BonnyCI/bonnyci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# bonnyci.org
+
+[![Build Status](https://travis-ci.org/BonnyCI/bonnyci.org.svg?branch=master)](https://travis-ci.org/BonnyCI/bonnyci.org)
+
+This is the repository for [bonnyci.org](http://bonnyci.org).

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor/bundle
+  - README.md
 include:
   - lore
   - status


### PR DESCRIPTION
Now we have a README.md with the Travis build status badge for the
repository, and a link to [bonnyci.org](http://bonnyci.org).

Related-Issue: BonnyCI/bonnyci.org#16
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>