### PR TITLE
Make Lore capitalized

### DIFF
--- a/lore/README.md
+++ b/lore/README.md
@@ -1,6 +1,6 @@
 ---
 name: lore
-title: lore
+title: Lore
 layout: default
 permalink: /lore/
 show_header_link: true


### PR DESCRIPTION
It shows up on the nav bar, and it was between "Status" and "About", so
it looked weird to be in all lower case.