### PR TITLE
Add lore for other status pages

### DIFF
--- a/lore/end_users/status/README.md
+++ b/lore/end_users/status/README.md
@@ -8,6 +8,7 @@ permalink: /lore/end_users/status
 
 ## Table of Contents
 
+* [Zuul Status](#zuul-status)
 * [BonnyCI Status ScreenBoard](#bonnyci-status-screenboard)
   * [System Load](#system-load)
   * [Disk Free](#disk-free)
@@ -15,9 +16,13 @@ permalink: /lore/end_users/status
   * [Zuul Pipelines](#zuul-pipelines)
   * [Service Status](#service-status)
 
+## Zuul Status
+
+The [Zuul Status page](http://zuul.bonnyci.org/) has information on queue length and pipelines. When code is being tested it is listed under the pipeline and provides links to more information about them.
+
 ## BonnyCI Status ScreenBoard
 
-This section explains the components of the [BonnyCI Status ScreenBoard](https://p.datadoghq.com/sb/cbf19e221-1b77fb05f2)
+This section explains the components of the [BonnyCI Status ScreenBoard](https://p.datadoghq.com/sb/cbf19e221-1b77fb05f2).
 
 ### System Load
 

--- a/status/README.md
+++ b/status/README.md
@@ -11,5 +11,5 @@ There are three status pages for BonnyCI:
 
 * [Zuul Status](http://zuul.bonnyci.org/)
 * [BonnyCI Status ScreenBoard](https://p.datadoghq.com/sb/cbf19e221-1b77fb05f2)
-  * See our [status page documentation](http://bonnyci.org/lore/end_users/status) for detailed explanations of what each item means
-* [Build Status](https://travis-ci.org/BonnyCI)
+
+See our [status page documentation](http://bonnyci.org/lore/end_users/status) for detailed explanations of what each item means.


### PR DESCRIPTION
Previously, our lore only included information on the BonnyCI Status
Screenboard. Now, it includes brief summaries of the Zuul Status,
and Build Status pages.

Related-Issues: BoonyCI/projman#123, BonnyCI/projman#125
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>