### PR TITLE
Fix build for missing last_modified_at tag

### DIFF
--- a/beta/README.md
+++ b/beta/README.md
@@ -186,9 +186,7 @@ space for future updates. If you want to join our closed beta, you can
 email me personally (see below) or join us on Freenode IRC in #BonnyCI.
 
 *Clint Byrum is a Cloud Architect at IBM, you can contact him
-via Twitter: @SpamapS, or email [clint at fewbar dot com](mailto:clint at fewbar dot com)
-
-Last Updated: {% last_modified_at %B %d, %Y %}*
+via Twitter: @SpamapS, or email [clint at fewbar dot com](mailto:clint at fewbar dot com)*
 
 [os]: http://www.openstack.org/
 [j]: http://www.jenkins.io/


### PR DESCRIPTION
I was mistaken thinking this plugin was available in GH pages, but it is
not.