### PR TITLE
Add permalink for beta announcement

### DIFF
--- a/beta/README.md
+++ b/beta/README.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title:  "Beta"
+permalink: /beta/
 show_header_link: true
 categories:
   - bonnyci


### PR DESCRIPTION
Previously, there was no permalink set for the beta announcement, which caused the beta announcement URL to be [bonnyci.org/beta/README.md](http://bonnyci.org/beta/README.md). Now, the beta announcement URL is [bonnyci.org/beta](http://bonnyci.org/beta/), which fits our existing pattern.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>