### PR TITLE
Add tests/filename-test.sh

### DIFF
--- a/.bonnyci/run.sh
+++ b/.bonnyci/run.sh
@@ -2,6 +2,7 @@
 sudo apt-get install -y curl
 curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
 sudo apt-get install -y nodejs ruby ruby-dev
+./tests/filename-test.sh
 ./tests/jekyll-build.sh
 ./tests/markdownlint-cli-test.sh
 ./tests/shellcheck-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
   fast_finish: true
 
 env:
+  - TEST_RUN="tests/filename-test.sh"
   - TEST_RUN="tests/markdownlint-cli-test.sh"
   - TEST_RUN="tests/shellcheck-test.sh"
   - TEST_RUN="tests/signed-off-by-test.sh"

--- a/tests/filename-test.sh
+++ b/tests/filename-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+FILENAME_LIST=$(find . -path './.git' -prune -o -wholename './index.md' -prune -o -name 'index*' -print)
+
+if ! [[ -z "$FILENAME_LIST" ]]; then
+    echo "ERROR: Files in BonnyCI/bonnyci.org should not be named index."
+    for FILENAME in $FILENAME_LIST; do
+        # shellcheck disable=SC2001
+        FILENAME_PATH=$(echo "$FILENAME" | sed 's/\/index.*$//')
+        if [[ "$FILENAME" != "*.md" ]]; then
+            echo "ERROR: $FILENAME's extension is not .md."
+            echo "SUGGESTION: Please ensure $FILENAME is written in Markdown, and name it $FILENAME_PATH/README.md."
+        else
+            echo "SUGGESTION: Consider renaming $FILENAME to $FILENAME_PATH/README.md."
+        fi
+    done
+    exit 1
+else
+    echo "SUCCESS: No unnecessary index files found."
+fi


### PR DESCRIPTION
Previously, we were not checking for index files. Now, we have a test
that checks for non-default index files (any file named index* other
than ./index.md and anything in ./.git) and suggests renaming them.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>