### PR TITLE
Add message about success or failure to CI tests

### DIFF
--- a/tests/markdownlint-cli-test.sh
+++ b/tests/markdownlint-cli-test.sh
@@ -2,4 +2,10 @@
 
 sudo npm install -g markdownlint-cli
 
-markdownlint -c .markdownlint.js .
+if ! markdownlint -c .markdownlint.js .; then
+    echo "ERROR: Markdown linting failed!"
+    echo "SUGGESTION: See messages above for specific issues."
+    exit 1
+else
+    echo "SUCCESS: Markdown linting passed!"
+fi

--- a/tests/shellcheck-test.sh
+++ b/tests/shellcheck-test.sh
@@ -2,4 +2,10 @@
 
 sudo apt-get install -y shellcheck
 
-find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -s bash
+if ! find . -name '*.sh' -print0 | xargs -n1 -0 shellcheck -s bash; then
+    echo "ERROR: Shell script linting failed!"
+    echo "SUGGESTION: See messages above for specific issues."
+    exit 1
+else
+    echo "SUCCESS: Shell script linting passed!"
+fi

--- a/tests/textlint-test.sh
+++ b/tests/textlint-test.sh
@@ -2,4 +2,10 @@
 
 sudo npm install -g textlint textlint-rule-alex textlint-rule-common-misspellings textlint-rule-no-dead-link textlint-rule-no-empty-section textlint-rule-rousseau textlint-rule-no-todo
 
-find . -name '*.md' -print0 | xargs -n1 -0 textlint -c .textlintrc.js -f pretty-error
+if ! find . -name '*.md' -print0 | xargs -n1 -0 textlint -c .textlintrc.js -f pretty-error; then
+    echo "ERROR: Text linting failed!"
+    echo "SUGGESTION: See messages above for specific issues."
+    exit 1
+else
+    echo "SUCCESS: Text linting passed!"
+fi


### PR DESCRIPTION
Previously, some of the tests in ./tests/ did not print a success
message, making CI logs difficult to understand. Now all tests print a
message on success or failure.

Related-Issue: BonnyCI/bonnyci.org#24
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>