### PR TITLE
Use bundle install, not update, in jekyll build

### DIFF
--- a/tests/jekyll-build.sh
+++ b/tests/jekyll-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eux
 sudo gem install github-pages bundler
-bundle update
+bundle install
 bundle exec jekyll build
 mv _site "$BONNYCI_TEST_LOG_DIR"


### PR DESCRIPTION
Update should only be run if we want to update the dependencies in
Gemfile.lock, which would typically be done by a developer.