### PR TITLE
Update lore for the new vagrant-deploy.sh

### DIFF
--- a/lore/developers/README.md
+++ b/lore/developers/README.md
@@ -37,7 +37,7 @@ $ cd hoist
 To perform a full deploy:
 
 ```shell
-$ vagrant up
+$ ./tools/vagrant-deploy.sh
 ```
 
 To redeploy just the nodepool VM:


### PR DESCRIPTION
Previously, our lore directed developers to use `vagrant up`, which, as
discussed in BonnyCI/projman#172, would not succeed. Now, lore indicates
the use of the new hoist/tools/vagrant-deploy.sh for creating a vagrant
development environment.

NOTE: Do not merge this change prior to BonnyCI/hoist#242.

Related-Issue: BonnyCI/projman#172
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>