### PR TITLE
Add lore for Docker development environment

### DIFF
--- a/lore/developers/README.md
+++ b/lore/developers/README.md
@@ -10,6 +10,7 @@ permalink: /lore/developers/
 
 * [Development Environment](#development-environment)
   * [Virtual Machines](#virtual-machines)
+  * [Docker](#docker)
 * [Contributing](#contributing)
 * [IRC](#irc)
 
@@ -70,6 +71,48 @@ To tear down the entire stack when you're done:
 
 ```shell
 $ vagrant destroy
+```
+
+## Docker
+
+You can test changes to BonnyCI locally by exercising some tools defined in
+[hoist](www.github.com/BonnyCI/hoist). Hoist is a set of ansible playbooks that
+automate the deployment of a BonnyCI environment. Be sure that you have
+completed the `Docker` section of your OS's [Development
+Environment](#development-environment) page before proceeding.
+
+Clone hoist and navigate to its base directory:
+
+```shell
+$ git clone git@github.com:BonnyCI/hoist.git
+$ cd hoist
+```
+
+To perform a full deploy:
+
+```shell
+$ ./tools/docker-deploy.sh
+```
+
+To inspect the container:
+
+```shell
+$ docker exec -it allinone /bin/bash
+$ # netstat, tcpdump, tail logs, etc.
+$ exit
+```
+
+To test changes to the zuul role:
+
+```shell
+$ ansible-playbook -i inventory/allinone install-ci.yml -c docker -e @secrets.yml.example --limit zuul
+```
+
+To tear down the entire stack when you're done:
+
+```shell
+$ docker stop allinone
+$ docker rm allinone
 ```
 
 ## Contributing

--- a/lore/developers/dev-environment/macOS.md
+++ b/lore/developers/dev-environment/macOS.md
@@ -10,10 +10,11 @@ layout: default
 * [Basic Tools](#basic-tools)
 * [Python Tools](#python-tools)
 * [Virtualization Tools](#virtualization-tools)
+* [Docker](#docker)
 
 ## Basic Tools
 
-Install [Homebrew](http://brew.sh/) to get a package manager.
+Install [Homebrew](https://brew.sh/) to get a package manager.
 
 Install some basic command line tools:
 
@@ -64,3 +65,7 @@ Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmana
 ```shell
 $ vagrant plugin install vagrant-hostmanager vagrant-triggers
 ```
+
+## Docker
+
+Follow the instructions in Docker's docs to [install Docker for Mac](https://docs.docker.com/docker-for-mac/install/).

--- a/lore/developers/dev-environment/ubuntu.md
+++ b/lore/developers/dev-environment/ubuntu.md
@@ -9,6 +9,7 @@ layout: default
 
 * [Python Tools](#python-tools)
 * [Virtualization Tools](#virtualization-tools)
+* [Docker](#docker)
 
 ## Python Tools
 
@@ -50,3 +51,7 @@ Install [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmana
 ```shell
 $ vagrant plugin install vagrant-hostmanager vagrant-triggers
 ```
+
+## Docker
+
+Follow the instructions in Docker's docs to [get Docker for Ubuntu](https://docs.docker.com/engine/installation/linux/ubuntu/).


### PR DESCRIPTION
Now our developer lore contains information on using
hoist/tools/docker-deploy.sh.

Related-Issue: BonnyCI/projman#177
Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>