### PR TITLE
Fix Docker header level

### DIFF
--- a/lore/developers/README.md
+++ b/lore/developers/README.md
@@ -73,7 +73,7 @@ To tear down the entire stack when you're done:
 $ vagrant destroy
 ```
 
-## Docker
+### Docker
 
 You can test changes to BonnyCI locally by exercising some tools defined in
 [hoist](www.github.com/BonnyCI/hoist). Hoist is a set of ansible playbooks that


### PR DESCRIPTION
Previously, the `Docker` section was set to a h2 tag, which was incorrect,
because it is listed under `Development Environment` (correctly set to
h2).

Now, `Docker` is a h3 tag, matching `Virtual Machines`.

Signed-off-by: Matt Langbehn <matthew.langbehn@gmail.com>