### PR TITLE
Add RCA documentation

### DIFF
--- a/lore/end_users/README.md
+++ b/lore/end_users/README.md
@@ -13,6 +13,7 @@ permalink: /lore/end_users/
 * [Bug Reports](#bug-reports)
 * [Feature Requests](#feature-requests)
 * [Status Page](#status-page)
+* [Outage Reports](#outage-reports)
 
 ## Setup
 
@@ -33,3 +34,7 @@ Check out the [feature request documentation](issues/README.md#feature-requests)
 ## Status Page
 
 Check out the [status page](../../status) for a list of BonnyCI's status pages.
+
+## Outage Reports
+
+Check out the [outage reports](rca/README.md) for an explination of the RCA process and a list of past outages.

--- a/lore/end_users/rca/README.md
+++ b/lore/end_users/rca/README.md
@@ -1,0 +1,34 @@
+---
+name: rca
+layout: default
+permalink: /lore/end_users/rca
+---
+
+# RCA Process and Past Reports
+
+## Table of Contents
+
+* [RCA process](#rca-process)
+* [Past Reports](#past-reports)
+
+## RCA Process
+
+When outages of the BonnyCI service are encountered, in the aftermath the team
+will conduct a Root Cause Analysis.  This process will identify exactly what
+went wrong, and what corrective steps should be taken to prevent future
+outages.  Each outage will have a corresponding RCA report which will be listed
+here, and each report should contain the following:
+
+* Introduction: A brief description of the outage and links to the projman
+  issue created for it.
+* Event Description: A clear and concise description of the problem, stating
+  date, time, detailed description of the event/problem, who detected it, who
+  it affected, and how they were affected.
+* Chronology of Events/Timeline: a detailed chronology of the events leading up
+  to, and following, the problem.
+* Investigative Team and Method: who investigated, what data was gathered, and
+  what methodologies were employed to conduct the RCA
+* Findings and Root Cause
+* Corrective Action: what should be done to ensure the event is not repeated.
+
+## Past Reports


### PR DESCRIPTION
Future outages should be documented and their root cause analyzed.  This proposes a framework for RCA reports and a place to house them.

Fixes BonnyCI/projman#188

Signed-off-by: matthew wagoner <zxkuqyb@gmail.com>